### PR TITLE
added: deployment on OpenShift

### DIFF
--- a/grabber.py
+++ b/grabber.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import sys
 import requests
 import os.path
 import re
@@ -16,6 +17,9 @@ from data import *
 USERNAME = ''
 COOKIES = {'ASP.NET_SessionId': ""}
 
+class _Misc(object):
+    pass
+_misc = _Misc()
 
 class LoginError(Exception):
     '''raise LoginError if error occurs in login process.
@@ -147,8 +151,10 @@ class TeapotParser():
         return lessons
 
     def _setup(self):
-        self.username = raw_input('Username: ')
-        self.password = getpass.getpass('Password: ')
+        #self.username = raw_input('Username: ')
+        #self.password = getpass.getpass('Password: ')
+        self.username = _misc.username
+        self.password = _misc.password
 
     def _get_cookies(self):
         url_default = self.url_prefix + "default2.aspx"
@@ -253,7 +259,17 @@ def gen_ical(courses):
                 cal.add_component(event)
     return cal.to_ical()
 
-if __name__ == "__main__":
+def main():
+    if len(sys.argv) < 3:
+        print('usage: %s username password [output_file]')
+        return
+    _misc.username = sys.argv[1]
+    _misc.password = sys.argv[2]
+    try: 
+        _misc.output_file = sys.argv[3]
+    except:
+        _misc.output_file = '%s.ics' %sys.argv[1]
+        
     grabber = TeapotParser()
     try:
         response = grabber.run()
@@ -262,8 +278,11 @@ if __name__ == "__main__":
     except:
         raise
     else:
-        with open(os.path.join(os.path.dirname(__file__), 'dump.yaml'), 'w') as log:
-            log.write(pretty_format(response))
-        with open(os.path.join(os.path.dirname(__file__), 'dump.ics'), 'w') as log:
+        #with open(os.path.join(os.path.dirname(__file__), 'dump.yaml'), 'w') as log:
+        #    log.write(pretty_format(response))
+        with open(os.path.join(os.path.dirname(__file__), _misc.output_file), 'w') as log:
             log.write(gen_ical(response))
         print "Dumped successfully."
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup
+
+setup(name='zjujwbtools',
+      version='0.1',
+      description='A simple application to dump icalendar file from jwbinfosys.zju.edu.cn',
+      author=['Dongyuan LIU', 'Pengyu CHEN'],
+      author_email=['liu.dongyuan@gmail.com', 'cpy.prefers.you@gmail.com'],
+      url='', # TBD
+      install_requires=['requests', 'beautifulsoup4', 'PyYAML', 'icalendar', 'bottle'],
+     )

--- a/wsgi/application
+++ b/wsgi/application
@@ -1,0 +1,25 @@
+#!/usr/bin/python
+import os
+
+virtenv = os.environ['OPENSHIFT_PYTHON_DIR'] + '/virtenv/'
+os.environ['PYTHON_EGG_CACHE'] = os.path.join(virtenv, 'lib/python2.6/site-packages')
+virtualenv = os.path.join(virtenv, 'bin/activate_this.py')
+try:
+    execfile(virtualenv, dict(__file__=virtualenv))
+except IOError:
+    pass
+#
+# IMPORTANT: Put any additional includes below this line.  If placed above this
+# line, it's possible required libraries won't be in your searchable path
+# 
+
+from testapp import application
+
+#
+# Below for testing only
+#
+if __name__ == '__main__':
+    from wsgiref.simple_server import make_server
+    httpd = make_server('localhost', 8051, application)
+    # Wait for a single request, serve it and quit.
+    httpd.handle_request()

--- a/wsgi/static/README
+++ b/wsgi/static/README
@@ -1,0 +1,12 @@
+Public, static content goes here.  Users can create rewrite rules to link to
+content in the static dir.  For example, django commonly uses /media/
+directories for static content.  For example in a .htaccess file in a
+wsgi/.htaccess location, developers could put:
+
+RewriteEngine On
+RewriteRule ^application/media/(.+)$ /static/media/$1 [L]
+
+Then copy the media/* content to yourapp/wsgi/static/media/ and it should
+just work.
+
+Note: The ^application/ part of the URI match is required.

--- a/wsgi/testapp.py
+++ b/wsgi/testapp.py
@@ -1,0 +1,38 @@
+#sucks 
+
+import os
+import random
+import bottle
+
+data_dir = os.getenv('OPENSHIFT_DATA_DIR', '~/app-root/data/')
+repo_dir = os.getenv('OPENSHIFT_REPO_DIR', '~/app-root/repo/')
+temp_dir = os.getenv('OPENSHIFT_TMP_DIR', '/tmp/')
+
+@bottle.get('/')
+@bottle.view(repo_dir + 'wsgi/view/index.html')
+def index():
+    return {}
+
+@bottle.post('/grab')
+def grab():
+    param = list(map(bottle.request.forms.get, ['zju_username', 'zju_password']))
+    if not all(param):
+        # TODO: post a redirection to '/' or at least add  a link to it
+        return 'Incomplete input fields. Needs username and password'
+    temp_filename = '%.8x_%s.ics' %(random.getrandbits(32), param[0])
+    # TODO: replace this with subprocess 
+    err = os.popen('%s %s %s %s' %(
+        repo_dir + 'grabber.py', 
+        param[0], param[1], 
+        '%s/%s' %(temp_dir, temp_filename))).read()
+    if os.path.exists('%s/%s' %(temp_dir, temp_filename)):
+        return bottle.static_file(temp_filename, root=temp_dir, download='%s.ics' %param[0])
+    else:
+        return err
+
+# This must be added in order to do correct path lookups for the views
+bottle.TEMPLATE_PATH.append(
+    os.path.join(os.environ['OPENSHIFT_HOMEDIR'], 'runtime/repo/wsgi/views/'))
+
+bottle.debug(True)
+application = bottle.default_app()

--- a/wsgi/view/index.html
+++ b/wsgi/view/index.html
@@ -1,0 +1,43 @@
+<html>
+  <head>
+   <title>zjujwbtools - a simple application to dump icalendar file from jwbinfosys.zju.edu.cn</title>
+   <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+   <link rel="icon" id="favicon" href="http://calendar.google.com/googlecalendar/images/favicon_v2010.ico"> 
+  </head>  
+  <body>
+   <h1>zjujwbtools</h1>  
+   
+   <h2>[Well here I'm only a testing page]</h2>
+   <p>
+    zjujwbtools will NOT record your password nor collect your personal information.
+   </p> 
+   <table>   
+    <form action="/grab" method="post">
+     <tr>
+      <td colspan="2">For jwbinfosys.zju.edu.cn: </td>
+     </tr>
+     <tr>
+      <td>Username: </td>
+      <td><input type="text" name="zju_username"/></td>
+     </tr>
+     <tr>
+      <td>Password: </td>
+      <td><input type="password" name="zju_password"/></td>
+     </tr>
+     <tr>
+      <td colspan="2"><input type="submit" value="Export Your ICal File"></td>
+     </tr> 
+    </form>
+   </table>   
+
+   <h2>Want to contact the developer?</h2>
+   <p>
+    Leave a message on this project's homepage on GitHub, or mail/gtalk to liu [dot] dongyuan [at] gmail [dot] com.
+   </p>
+   
+   <hr/>
+   Last updated: 2013-09-08
+   <br>
+  </body>
+</html>
+

--- a/wsgi/view/index.html
+++ b/wsgi/view/index.html
@@ -32,11 +32,11 @@
 
    <h2>Want to contact the developer?</h2>
    <p>
-    Leave a message on this project's homepage on GitHub, or mail/gtalk to liu [dot] dongyuan [at] gmail [dot] com.
+    Leave a message on this project's homepage on GitHub, or mail/gtalk to liu[dot]dongyuan[at]gmail[dot]com / cpy[dot]prefers[dot]you[at]gmail[dot]com
    </p>
    
    <hr/>
-   Last updated: 2013-09-08
+   Last updated: 2013-09-10
    <br>
   </body>
 </html>


### PR DESCRIPTION
Added deployment for OpenShift. Actually one can use this repo directly with OpenShift to obtain a working deployment, ...even he/she has no Git, Python, nor text editor installed -- what's needed is merely to follow the new application setup routine of OpenShift and enter the repo URL of this GitHub repository.

The original grabber.py has been changed: now it reads its command line arguments to obtain necessary information instead of requiring user interactive when running.
